### PR TITLE
Add reference-only disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> ⚠️ **Disclaimer:** This repository is a FreeRTOS Labs reference project, provided for demonstration and evaluation purposes only, and should not be used in production.
+
 # Delta Over-the-Air Updates Demo
 
 This repository contains example of using the


### PR DESCRIPTION
This adds a short disclaimer to the top of the README clarifying that this repository is a **FreeRTOS Labs reference project**, provided for demonstration and evaluation purposes only, and should not be used in production. No functional changes.